### PR TITLE
Исправления

### DIFF
--- a/src/Lexplosion.Core/Logic/FileSystem/Services/IFileServicesContainer.cs
+++ b/src/Lexplosion.Core/Logic/FileSystem/Services/IFileServicesContainer.cs
@@ -1,9 +1,10 @@
-﻿using Lexplosion.Logic.Network;
+﻿using Lexplosion.Logic.Management.Localization;
+using Lexplosion.Logic.Network;
 using Lexplosion.Logic.Network.Services;
 
 namespace Lexplosion.Logic.FileSystem.Services
 {
-	public interface IFileServicesContainer : IWebServicesContainer
+	public interface IFileServicesContainer : IWebServicesContainer, ILocalizationServicesContainer
 	{
 		public WithDirectory DirectoryService { get; }
 		public DataFilesManager DataFilesService { get; }

--- a/src/Lexplosion.Core/Logic/Management/Addons/CurseforgeAddon.cs
+++ b/src/Lexplosion.Core/Logic/Management/Addons/CurseforgeAddon.cs
@@ -10,6 +10,9 @@ using System.Runtime.CompilerServices;
 using Lexplosion.Logic.Network.Services;
 using Lexplosion.Logic.FileSystem.Services;
 using Lexplosion.Logic.FileSystem.Extensions;
+using Lexplosion.Global;
+using Lexplosion.Logic.Management;
+using Lexplosion.Logic.Management.Localization;
 
 namespace Lexplosion.Logic.Management.Addons
 {
@@ -66,7 +69,7 @@ namespace Lexplosion.Logic.Management.Addons
 		{
 			get
 			{
-				return _addonInfo?.GetAuthorName ?? "";
+				return _addonInfo?.GetAuthorName(Runtime.ServicesContainer.LocalizationService.GetString(LocalizationKeys.UnknownAuthor)) ?? "";
 			}
 		}
 

--- a/src/Lexplosion.Core/Logic/Management/Addons/CurseforgeAddon.cs
+++ b/src/Lexplosion.Core/Logic/Management/Addons/CurseforgeAddon.cs
@@ -69,7 +69,7 @@ namespace Lexplosion.Logic.Management.Addons
 		{
 			get
 			{
-				return _addonInfo?.GetAuthorName(Runtime.ServicesContainer.LocalizationService.GetString(LocalizationKeys.UnknownAuthor)) ?? "";
+				return _addonInfo?.GetAuthorName(_services.LocalizationService.GetUnknownAuthor()) ?? "";
 			}
 		}
 

--- a/src/Lexplosion.Core/Logic/Management/Addons/ModrinthAddon.cs
+++ b/src/Lexplosion.Core/Logic/Management/Addons/ModrinthAddon.cs
@@ -177,7 +177,7 @@ namespace Lexplosion.Logic.Management.Addons
 			}
 			else
 			{
-				AuthorName = Runtime.ServicesContainer.LocalizationService.GetString(LocalizationKeys.UnknownAuthor);
+				AuthorName = _services.LocalizationService.GetUnknownAuthor();
 			}
 		}
 

--- a/src/Lexplosion.Core/Logic/Management/Addons/ModrinthAddon.cs
+++ b/src/Lexplosion.Core/Logic/Management/Addons/ModrinthAddon.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System;
+using Lexplosion;
 using Lexplosion.Logic.Management.Instances;
+using Lexplosion.Logic.Management.Localization;
 using Lexplosion.Logic.Network.Services;
 using Lexplosion.Logic.FileSystem.Extensions;
 using Lexplosion.Logic.FileSystem.Services;
@@ -175,7 +177,7 @@ namespace Lexplosion.Logic.Management.Addons
 			}
 			else
 			{
-				AuthorName = "Unknown author";
+				AuthorName = Runtime.ServicesContainer.LocalizationService.GetString(LocalizationKeys.UnknownAuthor);
 			}
 		}
 

--- a/src/Lexplosion.Core/Logic/Management/AllServicesContainer.cs
+++ b/src/Lexplosion.Core/Logic/Management/AllServicesContainer.cs
@@ -1,5 +1,6 @@
 ﻿using Lexplosion.Logic.FileSystem;
 using Lexplosion.Logic.FileSystem.Services;
+using Lexplosion.Logic.Management.Localization;
 using Lexplosion.Logic.Management.Notifications;
 using Lexplosion.Logic.Network;
 using Lexplosion.Logic.Network.Services;
@@ -27,6 +28,26 @@ namespace Lexplosion.Logic.Management
 
         public CategoriesManager CategoriesService { get; }
         public NotificationsManager NotificationsService { get; internal set; }
+
+        private ILocalizationService _localizationService = NullLocalizationService.Instance;
+        private bool _localizationServiceSet = false;
+
+        public ILocalizationService LocalizationService
+        {
+            get => _localizationService;
+            internal set
+            {
+                if (_localizationServiceSet) return;
+                if (value == null) return;
+                _localizationService = value;
+                _localizationServiceSet = true;
+            }
+        }
+
+        public void SetLocalizationService(ILocalizationService localizationService)
+        {
+            LocalizationService = localizationService;
+        }
 
         public AllServicesContainer(ToServer webService, MinecraftInfoService minecraftService, WithDirectory directoryService, DataFilesManager dataFilesService, CurseforgeApi cfApi, ModrinthApi mdApi, NightWorldApi nwApi, MojangApi mjApi, CategoriesManager categoriesService, NotificationsManager notificationsService)
         {

--- a/src/Lexplosion.Core/Logic/Management/Instances/InstanceClient.cs
+++ b/src/Lexplosion.Core/Logic/Management/Instances/InstanceClient.cs
@@ -14,6 +14,7 @@ using Lexplosion.Logic.Objects.CommonClientData;
 using Lexplosion.Tools;
 using NightWorld.Tools.Minecraft.NBT.StorageFiles;
 using Newtonsoft.Json;
+using Lexplosion.Logic.Management.Localization;
 
 namespace Lexplosion.Logic.Management.Instances
 {
@@ -32,9 +33,6 @@ namespace Lexplosion.Logic.Management.Instances
 		private LaunchGame _gameManager = null;
 
 		private const string LogoFileName = "logo.png";
-		private const string UnknownName = "Unknown name";
-		private const string UnknownAuthor = "Unknown author";
-		private const string NoDescription = "Описания нет, но мы надеемся что оно будет.";
 
 		public static Func<byte[]> LogoGenerator { set; private get; }
 
@@ -109,7 +107,9 @@ namespace Lexplosion.Logic.Management.Instances
 		private string _description;
 		public string Description
 		{
-			get => _description;
+			get => string.IsNullOrEmpty(_description)
+				? _services.LocalizationService.GetString(LocalizationKeys.NoDescription)
+				: _description;
 			private set
 			{
 				_description = value;
@@ -172,7 +172,9 @@ namespace Lexplosion.Logic.Management.Instances
 		private string _summary;
 		public string Summary
 		{
-			get => _summary;
+			get => string.IsNullOrEmpty(_summary)
+				? _services.LocalizationService.GetString(LocalizationKeys.NoDescription)
+				: _summary;
 			private set
 			{
 				_summary = value;
@@ -330,8 +332,8 @@ namespace Lexplosion.Logic.Management.Instances
 		{
 			CreatedLocally = true;
 			Author = Account.AnyFuckingLogin;
-			Description = NoDescription;
-			Summary = NoDescription;
+			Description = null;
+			Summary = null;
 
 			if (modloaderVersion == null) modloader = ClientType.Vanilla;
 
@@ -446,12 +448,14 @@ namespace Lexplosion.Logic.Management.Instances
 				catch { }
 			}
 
+			var localizationService = _services.LocalizationService;
+
 			if (assetsData != null)
 			{
-				Name = name ?? UnknownName;
-				Summary = assetsData.Summary ?? NoDescription;
-				Author = assetsData.Author ?? UnknownAuthor;
-				Description = assetsData.Description ?? NoDescription;
+				Name = name ?? localizationService.GetString(LocalizationKeys.UnknownName);
+				Summary = NormalizePlaceholderText(assetsData.Summary, LocalizationKeys.NoDescription);
+				Author = assetsData.Author ?? localizationService.GetString(LocalizationKeys.UnknownAuthor);
+				Description = NormalizePlaceholderText(assetsData.Description, LocalizationKeys.NoDescription);
 				Categories = assetsData.Categories;
 				GameVersion = gameVersion;
 				Logo = logo;
@@ -459,10 +463,10 @@ namespace Lexplosion.Logic.Management.Instances
 			}
 			else
 			{
-				Name = name ?? UnknownName;
-				Summary = NoDescription;
-				Author = UnknownAuthor;
-				Description = NoDescription;
+				Name = name ?? localizationService.GetString(LocalizationKeys.UnknownName);
+				Summary = null;
+				Author = localizationService.GetString(LocalizationKeys.UnknownAuthor);
+				Description = null;
 				GameVersion = gameVersion;
 				Logo = logo;
 				_profileVersion = instanceVersion;
@@ -479,25 +483,27 @@ namespace Lexplosion.Logic.Management.Instances
 
 		internal void UpdateInfo(string name, MinecraftVersion gameVersion, IEnumerable<CategoryBase> categories, string summary, string description, string author, string websiteUrl)
 		{
+			var localizationService = _services.LocalizationService;
+
 			if (!string.IsNullOrEmpty(name))
 				Name = name;
 			else if (string.IsNullOrEmpty(Name))
-				Name = UnknownName;
+				Name = localizationService.GetString(LocalizationKeys.UnknownName);
 
 			if (!string.IsNullOrEmpty(summary))
 				Summary = summary;
-			else if (string.IsNullOrEmpty(Summary))
-				Summary = NoDescription;
+			else if (string.IsNullOrEmpty(_summary))
+				Summary = null;
 
 			if (!string.IsNullOrEmpty(description))
 				Description = description;
-			else if (string.IsNullOrEmpty(Description))
-				Description = NoDescription;
+			else if (string.IsNullOrEmpty(_description))
+				Description = null;
 
 			if (!string.IsNullOrEmpty(author))
 				Author = author;
 			else if (string.IsNullOrEmpty(Author))
-				Author = UnknownAuthor;
+				Author = localizationService.GetString(LocalizationKeys.UnknownAuthor);
 
 			if (categories != null)
 				Categories = categories;
@@ -511,7 +517,7 @@ namespace Lexplosion.Logic.Management.Instances
 		{
 			Name = tempName;
 			IsFictitious = true;
-			Author = UnknownAuthor;
+			Author = _services.LocalizationService.GetString(LocalizationKeys.UnknownAuthor);
 			Summary = string.Empty;
 			IsComplete = false;
 		}
@@ -560,7 +566,7 @@ namespace Lexplosion.Logic.Management.Instances
 					Categories = Categories,
 					Description = Description,
 					Name = _name,
-					Summary = _summary,
+					Summary = Summary,
 					ModloaderVersion = modloaderVersion,
 					Modloader = clientType,
 					OptifineVersion = optifineVersion,
@@ -582,10 +588,12 @@ namespace Lexplosion.Logic.Management.Instances
 				return null;
 			}
 
+			var localizationService = _services.LocalizationService;
+
 			if (fullInfo.Description == null)
-				fullInfo.Description = NoDescription;
+				fullInfo.Description = localizationService.GetString(LocalizationKeys.NoDescription);
 			if (fullInfo.Summary == null)
-				fullInfo.Summary = NoDescription;
+				fullInfo.Summary = localizationService.GetString(LocalizationKeys.NoDescription);
 
 			return fullInfo;
 		}
@@ -829,12 +837,25 @@ namespace Lexplosion.Logic.Management.Instances
 			{
 				Author = Author,
 				Categories = categories_,
-				Description = Description,
+				Description = NormalizePlaceholderText(_description, LocalizationKeys.NoDescription),
 				Images = (assetsData_ != null) ? assetsData_.Images : null,
-				Summary = Summary
+				Summary = NormalizePlaceholderText(_summary, LocalizationKeys.NoDescription)
 			};
 
 			_services.DataFilesService.SaveFile(file, JsonConvert.SerializeObject(assetsData));
+		}
+
+        /// <summary>
+        /// Если мы имеем дело с пустой строкой или строкой которая является плейсхолдером, то возвращает null. Иначе возвращает переданное значение.
+		/// Чтобы при отсутствии описания или при его плейсхолдере в файле ассетов сохранялось null, а не плейсхолдер или пустая строка. 
+		/// И при получении данных из файла ассетов не нужно было проверять на плейсхолдер и пустую строку, а просто проверять на null.
+        /// </summary>
+        private string NormalizePlaceholderText(string value, string placeholderKey)
+		{
+			if (string.IsNullOrWhiteSpace(value)) return null;
+
+			var placeholder = _services.LocalizationService.GetString(placeholderKey);
+			return value == placeholder ? null : value;
 		}
 
 		/// <summary>
@@ -1074,13 +1095,13 @@ namespace Lexplosion.Logic.Management.Instances
 			var parameters = new ArchivedClientData
 			{
 				Author = Author,
-				Description = Description,
+				Description = NormalizePlaceholderText(_description, LocalizationKeys.NoDescription),
 				GameVersionInfo = instanceManifest?.version?.GameVersionInfo,
 				ModloaderType = instanceManifest?.version?.ModloaderType ?? ClientType.Vanilla,
 				ModloaderVersion = instanceManifest?.version?.ModloaderVersion,
 				Name = name ?? Name,
 				//Categories = Categories,
-				Summary = Summary,
+				Summary = NormalizePlaceholderText(_summary, LocalizationKeys.NoDescription),
 				LogoFileName = (logoPath != null ? LogoFileName : null),
 				AdditionalInstallerType = instanceManifest?.version?.AdditionalInstaller?.type,
 				AdditionalInstallerVersion = instanceManifest?.version?.AdditionalInstaller?.installerVersion,

--- a/src/Lexplosion.Core/Logic/Management/Instances/InstanceClient.cs
+++ b/src/Lexplosion.Core/Logic/Management/Instances/InstanceClient.cs
@@ -108,7 +108,7 @@ namespace Lexplosion.Logic.Management.Instances
 		public string Description
 		{
 			get => string.IsNullOrEmpty(_description)
-				? _services.LocalizationService.GetString(LocalizationKeys.NoDescription)
+				? _services.LocalizationService.GetNoDescription()
 				: _description;
 			private set
 			{
@@ -173,7 +173,7 @@ namespace Lexplosion.Logic.Management.Instances
 		public string Summary
 		{
 			get => string.IsNullOrEmpty(_summary)
-				? _services.LocalizationService.GetString(LocalizationKeys.NoDescription)
+				? _services.LocalizationService.GetNoDescription()
 				: _summary;
 			private set
 			{
@@ -452,9 +452,9 @@ namespace Lexplosion.Logic.Management.Instances
 
 			if (assetsData != null)
 			{
-				Name = name ?? localizationService.GetString(LocalizationKeys.UnknownName);
+				Name = name ?? localizationService.GetUnknownName();
 				Summary = NormalizePlaceholderText(assetsData.Summary, LocalizationKeys.NoDescription);
-				Author = assetsData.Author ?? localizationService.GetString(LocalizationKeys.UnknownAuthor);
+				Author = assetsData.Author ?? localizationService.GetUnknownAuthor();
 				Description = NormalizePlaceholderText(assetsData.Description, LocalizationKeys.NoDescription);
 				Categories = assetsData.Categories;
 				GameVersion = gameVersion;
@@ -463,9 +463,9 @@ namespace Lexplosion.Logic.Management.Instances
 			}
 			else
 			{
-				Name = name ?? localizationService.GetString(LocalizationKeys.UnknownName);
+				Name = name ?? localizationService.GetUnknownName();
 				Summary = null;
-				Author = localizationService.GetString(LocalizationKeys.UnknownAuthor);
+				Author = localizationService.GetUnknownAuthor();
 				Description = null;
 				GameVersion = gameVersion;
 				Logo = logo;
@@ -488,7 +488,7 @@ namespace Lexplosion.Logic.Management.Instances
 			if (!string.IsNullOrEmpty(name))
 				Name = name;
 			else if (string.IsNullOrEmpty(Name))
-				Name = localizationService.GetString(LocalizationKeys.UnknownName);
+				Name = localizationService.GetUnknownName();
 
 			if (!string.IsNullOrEmpty(summary))
 				Summary = summary;
@@ -503,7 +503,7 @@ namespace Lexplosion.Logic.Management.Instances
 			if (!string.IsNullOrEmpty(author))
 				Author = author;
 			else if (string.IsNullOrEmpty(Author))
-				Author = localizationService.GetString(LocalizationKeys.UnknownAuthor);
+				Author = localizationService.GetUnknownAuthor();
 
 			if (categories != null)
 				Categories = categories;
@@ -517,7 +517,7 @@ namespace Lexplosion.Logic.Management.Instances
 		{
 			Name = tempName;
 			IsFictitious = true;
-			Author = _services.LocalizationService.GetString(LocalizationKeys.UnknownAuthor);
+			Author = _services.LocalizationService.GetUnknownAuthor();
 			Summary = string.Empty;
 			IsComplete = false;
 		}
@@ -591,9 +591,9 @@ namespace Lexplosion.Logic.Management.Instances
 			var localizationService = _services.LocalizationService;
 
 			if (fullInfo.Description == null)
-				fullInfo.Description = localizationService.GetString(LocalizationKeys.NoDescription);
+				fullInfo.Description = localizationService.GetNoDescription();
 			if (fullInfo.Summary == null)
-				fullInfo.Summary = localizationService.GetString(LocalizationKeys.NoDescription);
+				fullInfo.Summary = localizationService.GetNoDescription();
 
 			return fullInfo;
 		}

--- a/src/Lexplosion.Core/Logic/Management/Localization/ILocalizationService.cs
+++ b/src/Lexplosion.Core/Logic/Management/Localization/ILocalizationService.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Lexplosion.Logic.Management.Localization
+{
+    /// <summary>
+    /// Интерфейс для предоставления локализованных строк
+    /// </summary>
+    public interface ILocalizationService
+    {
+        /// <summary>
+        /// Возвращает локализованную строку для заданного ключа
+        /// </summary>
+        string GetString(string key);
+
+        /// <summary>
+        /// Идентификатор локали текущего активного языка
+        /// </summary>
+        string CurrentLanguageId { get; }
+
+        /// <summary>
+        /// Происходит после успешного переключения языка, когда новые данные перевода
+        /// полностью загружены. Компоненты UI подписываются для повторной загрузки строк
+        /// </summary>
+        event Action LanguageChanged;
+    }
+}

--- a/src/Lexplosion.Core/Logic/Management/Localization/ILocalizationServicesContainer.cs
+++ b/src/Lexplosion.Core/Logic/Management/Localization/ILocalizationServicesContainer.cs
@@ -1,0 +1,10 @@
+namespace Lexplosion.Logic.Management.Localization
+{
+	/// <summary>
+	/// Предоставляет доступ к сервису локализации
+	/// </summary>
+	public interface ILocalizationServicesContainer
+	{
+		ILocalizationService LocalizationService { get; }
+	}
+}

--- a/src/Lexplosion.Core/Logic/Management/Localization/LocalizationKeys.cs
+++ b/src/Lexplosion.Core/Logic/Management/Localization/LocalizationKeys.cs
@@ -1,0 +1,13 @@
+﻿namespace Lexplosion.Logic.Management.Localization
+{
+    /// <summary>
+    /// Просто типо дтошки, чтобы не хардкодить строки в коде, а использовать ключи для локализации
+    /// </summary>
+    public static class LocalizationKeys
+    {
+        public const string NoDescription = "NoDescription";
+        public const string UnknownName   = "UnknownName";
+        public const string UnknownAuthor = "UnknownAuthor";
+        public const string LaunchingGame = "LaunchingGame";
+    }
+}

--- a/src/Lexplosion.Core/Logic/Management/Localization/LocalizationServiceExtensions.cs
+++ b/src/Lexplosion.Core/Logic/Management/Localization/LocalizationServiceExtensions.cs
@@ -1,0 +1,20 @@
+namespace Lexplosion.Logic.Management.Localization
+{
+    /// <summary>
+    /// Extension methods для <see cref="ILocalizationService"/> предоставляющие типизированный доступ к локализованным строкам
+    /// <para>
+    /// Когда добавляете чето в <see cref="LocalizationKeys"/>, добавьте еще и сюда
+    /// </para>
+    /// </summary>
+    public static class LocalizationServiceExtensions
+    {
+        public static string GetNoDescription(this ILocalizationService service)
+            => service.GetString(LocalizationKeys.NoDescription);
+        public static string GetUnknownName(this ILocalizationService service)
+            => service.GetString(LocalizationKeys.UnknownName);
+        public static string GetUnknownAuthor(this ILocalizationService service)
+            => service.GetString(LocalizationKeys.UnknownAuthor);
+        public static string GetLaunchingGame(this ILocalizationService service)
+            => service.GetString(LocalizationKeys.LaunchingGame);
+    }
+}

--- a/src/Lexplosion.Core/Logic/Management/Localization/NullLocalizationService.cs
+++ b/src/Lexplosion.Core/Logic/Management/Localization/NullLocalizationService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Lexplosion.Logic.Management.Localization
+{
+    /// <summary>
+    /// Возвращает ключ как есть для каждого вызова GetString
+    /// Используется как значение по умолчанию в AllServicesContainer до тех пор, пока слой UI не внедрит свою реализацию
+    /// </summary>
+    internal sealed class NullLocalizationService : ILocalizationService
+    {
+        public static readonly NullLocalizationService Instance = new NullLocalizationService();
+
+        private NullLocalizationService() { }
+
+        public string CurrentLanguageId => string.Empty;
+
+        // Никогда не срабатывает в null реализации
+        public event Action LanguageChanged { add { } remove { } }
+
+        /// <summary>Возвращает <paramref name="key"/> без изменений, или <see cref="string.Empty"/> для null.</summary>
+        public string GetString(string key) => key ?? string.Empty;
+    }
+}

--- a/src/Lexplosion.Core/Logic/Objects/Curseforge.cs
+++ b/src/Lexplosion.Core/Logic/Objects/Curseforge.cs
@@ -55,12 +55,9 @@ namespace Lexplosion.Logic.Objects.Curseforge
 		public List<Author> authors;
 		public Logo logo;
 
-		public string GetAuthorName
+		public string GetAuthorName(string fallback = "")
 		{
-			get
-			{
-				return (authors != null && authors.Count > 0) ? authors[0].name : "Unknown author";
-			}
+			return (authors != null && authors.Count > 0) ? authors[0].name : fallback;
 		}
 	}
 

--- a/src/Lexplosion.UI.WPF/Assets/langs/de-DE.xaml
+++ b/src/Lexplosion.UI.WPF/Assets/langs/de-DE.xaml
@@ -812,4 +812,10 @@
     <s:String x:Key="RestartLauncherButtonAction">
         Ja, ich möchte den Launcher jetzt neu starten
     </s:String>
+
+    <!--  Core Localization Keys  -->
+    <s:String x:Key="NoDescription">Keine Beschreibung, aber wir hoffen, dass sie erscheinen wird.</s:String>
+    <s:String x:Key="UnknownName">Unbekannter Name</s:String>
+    <s:String x:Key="UnknownAuthor">Unbekannter Autor</s:String>
+    <s:String x:Key="LaunchingGame">Spiel wird gestartet...</s:String>
 </ResourceDictionary>

--- a/src/Lexplosion.UI.WPF/Assets/langs/en-US.xaml
+++ b/src/Lexplosion.UI.WPF/Assets/langs/en-US.xaml
@@ -1045,4 +1045,10 @@
     <!--  News  -->
     <s:String x:Key="NewsTitle">News</s:String>
     <s:String x:Key="CloseArticleButtonTooltip">Close the article</s:String>
+
+    <!--  Core Localization Keys  -->
+    <s:String x:Key="NoDescription">No description, but we hope it will appear.</s:String>
+    <s:String x:Key="UnknownName">Unknown name</s:String>
+    <s:String x:Key="UnknownAuthor">Unknown author</s:String>
+    <s:String x:Key="LaunchingGame">Launching game...</s:String>
 </ResourceDictionary>

--- a/src/Lexplosion.UI.WPF/Assets/langs/ru-RU.xaml
+++ b/src/Lexplosion.UI.WPF/Assets/langs/ru-RU.xaml
@@ -1045,4 +1045,10 @@
     <!--  News  -->
     <s:String x:Key="NewsTitle">Новости</s:String>
     <s:String x:Key="CloseArticleButtonTooltip">Закрыть статью</s:String>
+
+    <!--  Core Localization Keys  -->
+    <s:String x:Key="NoDescription">Описания нет, но мы надеемся что оно будет.</s:String>
+    <s:String x:Key="UnknownName">Неизвестное название</s:String>
+    <s:String x:Key="UnknownAuthor">Неизвестный автор</s:String>
+    <s:String x:Key="LaunchingGame">Запуск игры...</s:String>
 </ResourceDictionary>

--- a/src/Lexplosion.UI.WPF/Assets/langs/uk-UA.xaml
+++ b/src/Lexplosion.UI.WPF/Assets/langs/uk-UA.xaml
@@ -813,4 +813,10 @@
     <s:String x:Key="RestartLauncherButtonAction">
         Так, я хочу зараз перезапустити лаунчер
     </s:String>
+
+    <!--  Core Localization Keys  -->
+    <s:String x:Key="NoDescription">Опису немає, але ми сподіваємося, що він з'явиться.</s:String>
+    <s:String x:Key="UnknownName">Невідома назва</s:String>
+    <s:String x:Key="UnknownAuthor">Невідомий автор</s:String>
+    <s:String x:Key="LaunchingGame">Запуск гри...</s:String>
 </ResourceDictionary>

--- a/src/Lexplosion.UI.WPF/Assets/langs/zh-CN.xaml
+++ b/src/Lexplosion.UI.WPF/Assets/langs/zh-CN.xaml
@@ -490,4 +490,10 @@
     <s:String x:Key="RestartLauncherButtonAction">
         是的，我想现在重启启动器
     </s:String>
+
+    <!--  Core Localization Keys  -->
+    <s:String x:Key="NoDescription">暂无描述，但我们希望它会出现。</s:String>
+    <s:String x:Key="UnknownName">未知名称</s:String>
+    <s:String x:Key="UnknownAuthor">未知作者</s:String>
+    <s:String x:Key="LaunchingGame">正在启动游戏...</s:String>
 </ResourceDictionary>

--- a/src/Lexplosion.UI.WPF/Core/Objects/LanguageModel.cs
+++ b/src/Lexplosion.UI.WPF/Core/Objects/LanguageModel.cs
@@ -1,4 +1,4 @@
-﻿using Lexplosion.Global;
+using Lexplosion.Global;
 using System;
 using System.ComponentModel;
 using System.Globalization;
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace Lexplosion.UI.WPF.Core.Objects
 {
-    public struct LanguageModel : INotifyPropertyChanged
+    public class LanguageModel : INotifyPropertyChanged
     {
         public readonly CultureInfo _cultureInfo = null;
 

--- a/src/Lexplosion.UI.WPF/Core/WpfLocalizationService.cs
+++ b/src/Lexplosion.UI.WPF/Core/WpfLocalizationService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading;
+using System.Windows;
+using Lexplosion.Global;
+using Lexplosion.Logic.FileSystem;
+using Lexplosion.Logic.Management;
+using Lexplosion.Logic.Management.Localization;
+
+namespace Lexplosion.UI.WPF.Core
+{
+    /// <summary>
+    /// WPF-реализация <see cref="ILocalizationService"/>.
+    /// Оборачивает <see cref="App.Current.Resources"/> для поиска строк по ключу.
+    /// Владеет логикой переключения языка (SetLanguage), включая замену ResourceDictionary
+    /// и сохранение выбранного языка в настройках.
+    /// </summary>
+    public sealed class WpfLocalizationService : ILocalizationService
+    {
+        private readonly DataFilesManager _dataFilesManager;
+        private ResourceDictionary _currentLangDict;
+
+        /// <inheritdoc/>
+        public string CurrentLanguageId { get; private set; }
+
+        /// <inheritdoc/>
+        public event Action LanguageChanged;
+
+        /// <summary>
+        /// Создаёт сервис и загружает язык из <see cref="GlobalData.GeneralSettings.LanguageId"/>.
+        /// Если LanguageId пустой, определяет язык по культуре ОС и сохраняет его в настройках.
+        /// </summary>
+        public WpfLocalizationService(DataFilesManager dataFilesManager)
+        {
+            _dataFilesManager = dataFilesManager;
+
+            string langId = GlobalData.GeneralSettings.LanguageId;
+
+            if (string.IsNullOrWhiteSpace(langId))
+            {
+                langId = ResolveDefaultLanguage();
+                GlobalData.GeneralSettings.LanguageId = langId;
+                _dataFilesManager.SaveSettings(GlobalData.GeneralSettings);
+            }
+
+            LoadDictionary(langId);
+            CurrentLanguageId = langId;
+        }
+
+        /// <summary>
+        /// Возвращает локализованную строку для заданного ключа из активного ResourceDictionary.
+        /// Если ключ не найден — возвращает сам ключ (никогда не возвращает null).
+        /// </summary>
+        public string GetString(string key)
+        {
+            if (key == null) return string.Empty;
+            return App.Current.Resources[key] as string ?? key;
+        }
+
+        /// <summary>
+        /// Переключает активный язык. Является no-op, если <paramref name="languageId"/> совпадает
+        /// с текущим. После успешной смены обновляет настройки, сохраняет их и вызывает
+        /// <see cref="LanguageChanged"/>.
+        /// </summary>
+        public void SetLanguage(string languageId)
+        {
+            if (string.IsNullOrWhiteSpace(languageId)) return;
+            if (languageId == CurrentLanguageId) return;
+
+            LoadDictionary(languageId);
+            CurrentLanguageId = languageId;
+
+            GlobalData.GeneralSettings.LanguageId = languageId;
+            _dataFilesManager.SaveSettings(GlobalData.GeneralSettings);
+
+            LanguageChanged?.Invoke();
+        }
+
+        // ── private helpers ──────────────────────────────────────────────────────
+
+        private void LoadDictionary(string languageId)
+        {
+            var dict = new ResourceDictionary
+            {
+                Source = new Uri(RuntimeApp.LangPath + languageId + ".xaml")
+            };
+
+            // Убираем старый словарь языка (если он есть), чтобы не копились дубли
+            if (_currentLangDict != null)
+                App.Current.Resources.MergedDictionaries.Remove(_currentLangDict);
+
+            App.Current.Resources.MergedDictionaries.Add(dict);
+            _currentLangDict = dict;
+        }
+
+        private static string ResolveDefaultLanguage()
+        {
+            try
+            {
+                string culture = Thread.CurrentThread.CurrentCulture.ToString();
+                // Проверяем, существует ли XAML для данной культуры
+                _ = new ResourceDictionary
+                {
+                    Source = new Uri(RuntimeApp.LangPath + culture + ".xaml")
+                };
+                return culture;
+            }
+            catch
+            {
+                return "ru-RU";
+            }
+        }
+    }
+}

--- a/src/Lexplosion.UI.WPF/Main.cs
+++ b/src/Lexplosion.UI.WPF/Main.cs
@@ -466,46 +466,21 @@ namespace Lexplosion.UI.WPF
 		}
 
 
-		private static ResourceDictionary CurrentLangDict;
 		internal const string LangPath = AssetsPath + "langs/";
 
+        // Не интерфейс, так как нужно переключать язык в рантайме
+        internal static WpfLocalizationService _wpfLocalizationService;
+
+		/// <summary>
+		/// Создаёт <see cref="WpfLocalizationService"/>, загружает язык и регистрирует сервис
+		/// в <see cref="Runtime.ServicesContainer"/>.
+		/// </summary>
 		public static void LoadCurrentLanguage()
 		{
-			var selectedLangId = GlobalData.GeneralSettings.LanguageId;
+			_wpfLocalizationService = new WpfLocalizationService(
+				Runtime.ServicesContainer.DataFilesService);
 
-			if (string.IsNullOrWhiteSpace(selectedLangId))
-			{
-				try
-				{
-					if (GlobalData.GeneralSettings.LanguageId.Length == 0)
-					{
-						var currentCultureName = Thread.CurrentThread.CurrentCulture.ToString();
-						//switch () тут код для стран cis
-						CurrentLangDict.Source = new Uri(LangPath + currentCultureName + ".xaml");
-						GlobalData.GeneralSettings.LanguageId = currentCultureName;
-						Runtime.ServicesContainer.DataFilesService.SaveSettings(GlobalData.GeneralSettings);
-					}
-					else
-					{
-						CurrentLangDict.Source = new Uri(LangPath + GlobalData.GeneralSettings.LanguageId + ".xaml");
-					}
-				}
-				catch
-				{
-					CurrentLangDict.Source = new Uri(LangPath + "ru-RU.xaml");
-					GlobalData.GeneralSettings.LanguageId = "ru-RU";
-					Runtime.ServicesContainer.DataFilesService.SaveSettings(GlobalData.GeneralSettings);
-				}
-			}
-			else
-			{
-
-			}
-
-			App.Current.Resources.MergedDictionaries.Add(new ResourceDictionary()
-			{
-				Source = new Uri("pack://application:,,,/Assets/langs/" + selectedLangId + ".xaml")
-			});
+			Runtime.ServicesContainer.SetLocalizationService(_wpfLocalizationService);
 		}
 
 		private static void ResourcesDictionariesRegister()

--- a/src/Lexplosion.UI.WPF/Mvvm/Models/MainContent/MainMenu/GeneralSettings/LanguageSettingsModel.cs
+++ b/src/Lexplosion.UI.WPF/Mvvm/Models/MainContent/MainMenu/GeneralSettings/LanguageSettingsModel.cs
@@ -1,11 +1,8 @@
 ﻿using Lexplosion.Global;
-using Lexplosion.Logic.FileSystem;
 using Lexplosion.UI.WPF.Core;
 using Lexplosion.UI.WPF.Core.Objects;
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Windows;
 
 namespace Lexplosion.UI.WPF.Mvvm.Models.MainContent.Content.GeneralSettings
 {
@@ -47,10 +44,7 @@ namespace Lexplosion.UI.WPF.Mvvm.Models.MainContent.Content.GeneralSettings
 
         public void ChangeLangauge(string cultureId)
         {
-            App.Current.Resources.MergedDictionaries.Add(new ResourceDictionary()
-            {
-                Source = new Uri("pack://application:,,,/Assets/langs/" + cultureId + ".xaml")
-            });
+            RuntimeApp._wpfLocalizationService.SetLanguage(cultureId);
         }
 
         private void OnLanguageModelChanged(LanguageModel langModel, string cultureId)
@@ -58,8 +52,6 @@ namespace Lexplosion.UI.WPF.Mvvm.Models.MainContent.Content.GeneralSettings
             _selectedLang.IsSelected = false;
             _selectedLang = langModel;
             ChangeLangauge(cultureId);
-            GlobalData.GeneralSettings.LanguageId = cultureId;
-			Runtime.ServicesContainer.DataFilesService.SaveSettings(GlobalData.GeneralSettings);
         }
     }
 }

--- a/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/MainMenu/Content/GeneralSettings/LanguageSettingsView.xaml
+++ b/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/MainMenu/Content/GeneralSettings/LanguageSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Lexplosion.UI.WPF.Mvvm.Views.Pages.MainContent.MainMenu.LanguageSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -18,7 +18,6 @@
         <DataTemplate DataType="{x:Type objects:LanguageModel}">
             <RadioButton
                 Margin="0,8,0,0"
-                GroupName="Language"
                 IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
                 Style="{StaticResource LanguageSelectorButton}">
                 <Grid ShowGridLines="False">


### PR DESCRIPTION
# Изменения


1. Обновление плейсхолдеров для отсутсвующих полей при изменении языка в настройках
2. Сохранение состояния языка радиокнопки при его изменении и выходе из настроек
3. Сохранение плейсхолдеров в качестве null значений с последующей трансляцией на языки

Протестировано в ручную, тесты не писала, если надо - сделаю. Коммиты постепенные, так что лучше думаю поревьюить с них. Так же там есть вопросы по поводу struct, что мешала нормально менять язык. Попробуйте войти и выйти из настроек при изменеии языка, он физически меняется, но визуально нет, на этой ветке все оке

---
<img width="140" height="32" alt="text" src="https://github.com/user-attachments/assets/529f8f7b-4fa9-4520-a3f8-59796c6b9c71" />

Добавила контейнер локализации, что теперь наследуюет контейнер для файлов. Заменила в аддонах обращение к именам через ексеншн метод


Есть еще предложение на подумать
<img width="1410" height="372" alt="Мысли" src="https://github.com/user-attachments/assets/1ff29106-c0c9-411b-b54d-684dce1a106e" />
Нужно ли чтобы здесь был просто плейсхолдер, либо же, как это есть сейчас, подставляемый текст?