### PR TITLE
Dev 55 fix custom jvm args

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,8 @@
-﻿[*.cs]
+﻿[*]
+indent_style = tab
+tab_width = 4
+
+[*.cs]
 
 # IDE0058: Значение выражения никогда не используется
 csharp_style_unused_value_expression_statement_preference = discard_variable
@@ -8,3 +12,4 @@ dotnet_diagnostic.IDE0058.severity = none
 
 # Default severity for analyzer diagnostics with category 'Style'
 dotnet_analyzer_diagnostic.category-Style.severity = none
+

--- a/src/Lexplosion.Core/Logic/Management/LaunchGame.cs
+++ b/src/Lexplosion.Core/Logic/Management/LaunchGame.cs
@@ -423,21 +423,21 @@ namespace Lexplosion.Logic.Management
 			else
 			{
 				builder.AddJvmArgs($"-Djava.library.path=\"{gamePath}natives/{(data.VersionFile.CustomVersionName ?? data.VersionFile.GameVersion)}\" -cp {libs}");
-			string userJvmArgs = JvmArgsParser.StripHeapFlags(_settings.JVMArgs ?? "");
-			var gcFlags = JvmArgsParser.DetectGcFlags(userJvmArgs);
-			if (gcFlags.Count > 0)
-			{
-				int javaMajorVer = JvmArgsParser.ParseJavaMajorVersion(_javaVersionName);
-				foreach (string flag in gcFlags)
+				string userJvmArgs = JvmArgsParser.StripHeapFlags(_settings.JVMArgs ?? "");
+				var gcFlags = JvmArgsParser.DetectGcFlags(userJvmArgs);
+				if (gcFlags.Count > 0)
 				{
-					if (!JvmArgsParser.IsGcFlagCompatible(flag, javaMajorVer))
+					int javaMajorVer = JvmArgsParser.ParseJavaMajorVersion(_javaVersionName);
+					foreach (string flag in gcFlags)
 					{
+						if (!JvmArgsParser.IsGcFlagCompatible(flag, javaMajorVer))
+						{
 							Runtime.DebugWrite($"JVM arg warning: removing incompatible GC flag '{flag}' (requires Java {(javaMajorVer < 0 ? "?" : javaMajorVer.ToString())}, current: {_javaVersionName ?? "unknown"})");
 							userJvmArgs = userJvmArgs.Replace(flag, "").Trim();
+						}
 					}
 				}
-			}
-			builder.AddJvmArgs(userJvmArgs);
+				builder.AddJvmArgs(userJvmArgs);
 
 				if (_keyStorePath != null)
 				{

--- a/src/Lexplosion.Core/Logic/Management/LaunchGame.cs
+++ b/src/Lexplosion.Core/Logic/Management/LaunchGame.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using Lexplosion.Core.Tools;
 using Lexplosion.Global;
 using Lexplosion.Tools;
 using Lexplosion.Logic.Objects;
@@ -31,6 +32,7 @@ namespace Lexplosion.Logic.Management
 		private readonly WithDirectory _withDirectory;
 		private readonly DataFilesManager _dataFilesManager;
 		private string _javaPath = string.Empty;
+		private string _javaVersionName;
 		private bool _processIsWork;
 
 		private static LaunchGame _classInstance = null;
@@ -372,7 +374,21 @@ namespace Lexplosion.Logic.Management
 					builder.AddJvmArgs("-Djavax.net.ssl.trustStore=\"" + _keyStorePath + "\"");
 				}
 
-				builder.AddJvmArgs(_settings.JVMArgs);
+				string userJvmArgs = JvmArgsParser.StripHeapFlags(_settings.JVMArgs ?? "");
+				var gcFlags = JvmArgsParser.DetectGcFlags(userJvmArgs);
+				if (gcFlags.Count > 0)
+				{
+					int javaMajorVer = JvmArgsParser.ParseJavaMajorVersion(_javaVersionName);
+					foreach (string flag in gcFlags)
+					{
+						if (!JvmArgsParser.IsGcFlagCompatible(flag, javaMajorVer))
+						{
+							Runtime.DebugWrite($"JVM arg warning: removing incompatible GC flag '{flag}' (requires Java {(javaMajorVer < 0 ? "?" : javaMajorVer.ToString())}, current: {_javaVersionName ?? "unknown"})");
+							userJvmArgs = userJvmArgs.Replace(flag, "").Trim();
+						}
+					}
+				}
+				builder.AddJvmArgs(userJvmArgs);
 				builder.AddJvmArgs(@"-Dfml.ignoreInvalidMinecraftCertificates=true -Dfml.ignorePatchDiscrepancies=true -XX:TargetSurvivorRatio=90");
 				builder.AddJvmArgs("-Dhttp.agent=\"Mozilla/5.0\"");
 				builder.AddJvmArgs("-Djava.net.preferIPv4Stack=true");
@@ -407,7 +423,21 @@ namespace Lexplosion.Logic.Management
 			else
 			{
 				builder.AddJvmArgs($"-Djava.library.path=\"{gamePath}natives/{(data.VersionFile.CustomVersionName ?? data.VersionFile.GameVersion)}\" -cp {libs}");
-				builder.AddJvmArgs(_settings.JVMArgs);
+			string userJvmArgs = JvmArgsParser.StripHeapFlags(_settings.JVMArgs ?? "");
+			var gcFlags = JvmArgsParser.DetectGcFlags(userJvmArgs);
+			if (gcFlags.Count > 0)
+			{
+				int javaMajorVer = JvmArgsParser.ParseJavaMajorVersion(_javaVersionName);
+				foreach (string flag in gcFlags)
+				{
+					if (!JvmArgsParser.IsGcFlagCompatible(flag, javaMajorVer))
+					{
+							Runtime.DebugWrite($"JVM arg warning: removing incompatible GC flag '{flag}' (requires Java {(javaMajorVer < 0 ? "?" : javaMajorVer.ToString())}, current: {_javaVersionName ?? "unknown"})");
+							userJvmArgs = userJvmArgs.Replace(flag, "").Trim();
+					}
+				}
+			}
+			builder.AddJvmArgs(userJvmArgs);
 
 				if (_keyStorePath != null)
 				{
@@ -736,6 +766,7 @@ namespace Lexplosion.Logic.Management
 					// Если не использовать _customJavaPath, то для новых версий мы можем выбрать Java17Path, даже если в настройках
 					// сборки прописана конретная версия джавы, а это нам не надо.
 					_javaPath = _customJavaPath;
+					_javaVersionName = javaVersionName;
 					javaIsNotDefined = false;
 				}
 				else
@@ -744,6 +775,7 @@ namespace Lexplosion.Logic.Management
 					if (!string.IsNullOrWhiteSpace(javaPath))
 					{
 						_javaPath = javaPath;
+						_javaVersionName = javaVersionName;
 						javaIsNotDefined = false;
 					}
 				}
@@ -807,6 +839,7 @@ namespace Lexplosion.Logic.Management
 					if (checkResult == JavaChecker.CheckResult.Successful)
 					{
 						_javaPath = _withDirectory.DirectoryPath + "/java/versions/" + javaVersion.JavaName + javaVersion.ExecutableFile;
+						_javaVersionName = javaVersion.JavaName;
 						Runtime.DebugWrite("JavaPath " + _javaPath);
 					}
 					else
@@ -857,6 +890,7 @@ namespace Lexplosion.Logic.Management
 							if (!string.IsNullOrWhiteSpace(_customJavaPath))
 							{
 								_javaPath = _customJavaPath;
+								_javaVersionName = files.version.JavaVersionName;
 								javaIsNotDefined = false;
 							}
 							else
@@ -865,6 +899,7 @@ namespace Lexplosion.Logic.Management
 								if (!string.IsNullOrWhiteSpace(javaPath))
 								{
 									_javaPath = javaPath;
+									_javaVersionName = files.version.JavaVersionName;
 									javaIsNotDefined = false;
 								}
 							}
@@ -884,6 +919,7 @@ namespace Lexplosion.Logic.Management
 								}
 
 								_javaPath = _withDirectory.DirectoryPath + "/java/versions/" + javaInfo.JavaName + javaInfo.ExecutableFile;
+								_javaVersionName = javaInfo.JavaName;
 							}
 						}
 

--- a/src/Lexplosion.Core/Tools/JvmArgsParser.cs
+++ b/src/Lexplosion.Core/Tools/JvmArgsParser.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Lexplosion.Core.Tools
+{
+    public static class JvmArgsParser
+    {
+        private static readonly Regex HeapFlagPattern = new(
+            @"\-Xm[xs]\d+[kKmMgGtT]?",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex GcFlagPattern = new(
+            @"\-XX:\+?(Use\w+GC|ZGCGenerational|UnlockExperimentalVMOptions)",
+            RegexOptions.Compiled);
+
+        private static readonly Dictionary<string, int> GcFlagMinVersion = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["UseZGC"] = 15,
+            ["ZGCGenerational"] = 21,
+            ["UseShenandoahGC"] = 15,
+            ["UseConcMarkSweepGC"] = 5,
+            ["UseG1GC"] = 7,
+            ["UseParallelGC"] = 5,
+            ["UseSerialGC"] = 5,
+            ["UnlockExperimentalVMOptions"] = 7,
+        };
+
+        private static readonly Dictionary<string, int> JavaNameMajorVersion = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["jre-legacy"] = 8,
+            ["jre8"] = 8,
+            ["jre11"] = 11,
+            ["jre17"] = 17,
+            ["jre21"] = 21,
+        };
+
+        public static string StripHeapFlags(string args)
+        {
+            if (string.IsNullOrWhiteSpace(args))
+                return args ?? string.Empty;
+
+            return HeapFlagPattern.Replace(args, "").Trim();
+        }
+
+        public static List<string> DetectGcFlags(string args)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(args))
+                return result;
+
+            foreach (Match match in GcFlagPattern.Matches(args))
+            {
+                result.Add(match.Value);
+            }
+
+            return result;
+        }
+
+        public static bool IsGcFlagCompatible(string flag, int javaMajorVersion)
+        {
+            if (javaMajorVersion <= 0)
+                return true;
+
+            foreach (var kvp in GcFlagMinVersion)
+            {
+                if (flag.IndexOf(kvp.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return javaMajorVersion >= kvp.Value;
+                }
+            }
+
+            return true;
+        }
+
+        public static int ParseJavaMajorVersion(string javaVersionName)
+        {
+            if (string.IsNullOrWhiteSpace(javaVersionName))
+                return 0;
+
+            if (JavaNameMajorVersion.TryGetValue(javaVersionName.Trim().ToLowerInvariant(), out int version))
+                return version;
+
+            if (javaVersionName.StartsWith("jre", StringComparison.OrdinalIgnoreCase))
+            {
+                string numPart = javaVersionName.Substring(3);
+                if (int.TryParse(numPart, out int parsed))
+                    return parsed;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Lexplosion.UI.WPF/Mvvm/Models/MainContent/InstanceProfile/Settings/InstanceProfileSettingsModel.cs
+++ b/src/Lexplosion.UI.WPF/Mvvm/Models/MainContent/InstanceProfile/Settings/InstanceProfileSettingsModel.cs
@@ -138,12 +138,14 @@ namespace Lexplosion.UI.WPF.Mvvm.Models.MainContent.InstanceProfile.Settings
                     InstanceSettings.JavaPath = value;
                     _instanceSettingsCopy.JavaPath = value;
                     InstanceSettings.IsCustomJava = true;
+                    _instanceSettingsCopy.IsCustomJava = true;
                 }
                 else if (javaPathResult == JavaHelper.JavaPathCheckResult.EmptyOrNull)
                 {
                     InstanceSettings.JavaPath = value;
                     _instanceSettingsCopy.JavaPath = value;
                     InstanceSettings.IsCustomJava = false;
+                    _instanceSettingsCopy.IsCustomJava = false;
                 }
 
                 Notify?.Invoke(javaPathResult);

--- a/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/InstanceProfile/Settings/InstanceProfileSettingsView.xaml
+++ b/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/InstanceProfile/Settings/InstanceProfileSettingsView.xaml
@@ -497,7 +497,7 @@
                             Height="32"
                             Margin="16,0,0,0"
                             HorizontalAlignment="Right"
-                            Text="{Binding Model.JVMArgs}" />
+                            Text="{Binding Model.JVMArgs, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
                 </Border>
             </StackPanel>

--- a/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/MainMenu/Content/GeneralSettings/GeneralSettingsView.xaml
+++ b/src/Lexplosion.UI.WPF/Mvvm/Views/Pages/MainContent/MainMenu/Content/GeneralSettings/GeneralSettingsView.xaml
@@ -641,7 +641,7 @@
                                 Height="32"
                                 Margin="16,0,0,0"
                                 HorizontalAlignment="Right"
-                                Text="{Binding Model.JVMArgs}" />
+                                Text="{Binding Model.JVMArgs, UpdateSourceTrigger=PropertyChanged}" />
                         </Grid>
                     </Border>
                 </StackPanel>


### PR DESCRIPTION
#### 1. Fix: Custom Java path not applied when set in instance profile settings
InstanceProfileSettingsModel.cs — The JavaPath setter set IsCustomJava = true on InstanceSettings but never synced it to _instanceSettingsCopy. Since _instanceModel.Settings = _instanceSettingsCopy persisted the copy, IsCustomJava was still null when LaunchGame checked it, causing the custom path to be silently ignored and falling back to managed Java 21.

#### 2. Feat: JVM argument paste & compatibility fixes
Two XAML files — Added UpdateSourceTrigger=PropertyChanged to JVM args TextBox bindings so pasted text is immediately written to the model (WPF defaults to LostFocus, making pasted args appear to do nothing).
New: JvmArgsParser.cs — Static utility that:
- Strips duplicate -Xmx/-Xms from user-provided args (the memory slider is the canonical source)
- Detects GC flags (-XX:+UseZGC, -XX:+ZGCGenerational, etc.)
- Checks compatibility against the resolved Java version name (jre-legacy → 8, jre17 → 17, etc.)
LaunchGame.cs — At launch time, user JVM args are sanitized through the parser. Incompatible GC flags (e.g. -XX:+ZGCGenerational on Java < 21) are stripped with a debug-log warning, preventing Minecraft from crashing at VM init.